### PR TITLE
fix: #issue-23 - add enr production in ep conso (photovoltaique)

### DIFF
--- a/src/16.2_production_enr.js
+++ b/src/16.2_production_enr.js
@@ -40,8 +40,11 @@ export class ProductionENR {
       // Calcul de l'électricité auto-consommée pour chaque enveloppe
       this.calculateConsoElecAc(productionElectricite, productionElecEnr, conso, zc_id, th, Sh);
 
-      // Mise à jour des consommations ef en minorant l'énergie consommée par l'énergie autoconsommée par le poste
+      // Mise à jour des consommations d'énergie finale en minorant l'énergie consommée par l'énergie autoconsommée par le poste
       this.updateEfConso(productionElectricite, conso, Sh);
+
+      // Mise à jour des consommations d'énergie primaire en minorant l'énergie consommée par l'énergie autoconsommée par le poste
+      this.updateEPConso(productionElectricite, conso, Sh);
     }
 
     return {
@@ -150,9 +153,9 @@ export class ProductionENR {
   }
 
   /**
-   * Mise à jour des consommations ef en minorant l'énergie consommée par l'énergie autoconsommée par chaque enveloppe
+   * Mise à jour des consommations ef en minorant l'énergie finale consommée par l'énergie autoconsommée par chaque enveloppe
    * @param productionElectricite
-   * @param conso
+   * @param conso {{ef_conso: Ef_conso}}
    * @param Sh
    */
   updateEfConso(productionElectricite, conso, Sh) {
@@ -170,6 +173,29 @@ export class ProductionENR {
       productionElectricite.conso_elec_ac_auxiliaire;
 
     conso.ef_conso.conso_5_usages_m2 = Math.floor(conso.ef_conso.conso_5_usages / Sh);
+  }
+
+  /**
+   * Mise à jour des consommations ef en minorant l'énergie primaire consommée par l'énergie autoconsommée par chaque enveloppe
+   * @param productionElectricite
+   * @param conso {{ep_conso: Ep_conso}}
+   * @param Sh
+   */
+  updateEPConso(productionElectricite, conso, Sh) {
+    conso.ep_conso.ep_conso_ecs -= productionElectricite.conso_elec_ac_ecs;
+    conso.ep_conso.ep_conso_ch -= productionElectricite.conso_elec_ac_ch;
+    conso.ep_conso.ep_conso_fr -= productionElectricite.conso_elec_ac_fr;
+    conso.ep_conso.ep_conso_eclairage -= productionElectricite.conso_elec_ac_eclairage;
+    conso.ep_conso.ep_conso_totale_auxiliaire -= productionElectricite.conso_elec_ac_auxiliaire;
+
+    conso.ep_conso.ep_conso_5_usages -=
+      productionElectricite.conso_elec_ac_ecs +
+      productionElectricite.conso_elec_ac_ch +
+      productionElectricite.conso_elec_ac_fr +
+      productionElectricite.conso_elec_ac_eclairage +
+      productionElectricite.conso_elec_ac_auxiliaire;
+
+    conso.ep_conso.ep_conso_5_usages_m2 = Math.floor(conso.ep_conso.ep_conso_5_usages / Sh);
   }
 
   /**

--- a/src/16.2_production_enr.spec.js
+++ b/src/16.2_production_enr.spec.js
@@ -104,6 +104,42 @@ describe('production ENR unit tests', () => {
     });
   });
 
+  test('should update ep conso', () => {
+    const productionElectricite = {
+      conso_elec_ac_fr: 100,
+      conso_elec_ac_ch: 150,
+      conso_elec_ac_ecs: 200,
+      conso_elec_ac_eclairage: 250,
+      conso_elec_ac_auxiliaire: 300
+    };
+
+    const conso = {
+      ep_conso: {
+        ep_conso_ecs: 1000,
+        ep_conso_ch: 500,
+        ep_conso_fr: 800,
+        ep_conso_eclairage: 900,
+        ep_conso_totale_auxiliaire: 1250,
+        ep_conso_5_usages: 1500,
+        ep_conso_5_usages_m2: 100
+      }
+    };
+
+    productionENR.updateEPConso(productionElectricite, conso, 10);
+
+    expect(conso).toStrictEqual({
+      ep_conso: {
+        ep_conso_ecs: 800,
+        ep_conso_ch: 350,
+        ep_conso_fr: 700,
+        ep_conso_eclairage: 650,
+        ep_conso_totale_auxiliaire: 950,
+        ep_conso_5_usages: 500,
+        ep_conso_5_usages_m2: 50
+      }
+    });
+  });
+
   test('should get tapl', () => {
     let productionElectricite = productionENR.getTapl({}, {}, 158, 2500);
 


### PR DESCRIPTION
Prise en compte de la production ENR photovoltaïque dans le calcul de l'énegrie primaire.

Closes #23 