### PR TITLE
feature request: expose  in main export for external integration

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
 import { calcul_3cl } from './src/index.js';
 export { calcul_3cl };
-import { Umur, Uph, Upb, Uporte, Ubv, Upt } from './src/3_deperdition.js';
-export { Umur, Uph, Upb, Uporte, Ubv, Upt };
+import { Umur, Uph, Upb, Uporte, Ubv, Upt, calc_deperdition } from './src/3_deperdition.js';
+export { Umur, Uph, Upb, Uporte, Ubv, Upt, calc_deperdition };


### PR DESCRIPTION
**fixes #64**
This PR exposes `calc_deperdition` via the main `index.js` export. This enables its reuse in external simulators such as the one developed at ECAIR. The change mirrors the structure used for other computation bricks like `Umur` and `Upb`, and does not introduce any breaking change.