### PR TITLE
fix: export classe dpe ges function

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import { calcul_3cl } from './src/index.js';
-export { calcul_3cl };
+import { calcul_3cl, get_classe_ges_dpe } from './src/index.js';
+export { calcul_3cl, get_classe_ges_dpe };
 import { Umur, Uph, Upb, Uporte, Ubv, Upt, calc_deperdition } from './src/3_deperdition.js';
 export { Umur, Uph, Upb, Uporte, Ubv, Upt, calc_deperdition };

--- a/src/conso.js
+++ b/src/conso.js
@@ -295,7 +295,7 @@ export default function calc_conso(
   return ret;
 }
 
-function classe_bilan_dpe(ep_conso_5_usages_m2, zc_id, ca_id, Sh) {
+export function classe_bilan_dpe(ep_conso_5_usages_m2, zc_id, ca_id, Sh) {
   const ca = enums.classe_altitude[ca_id];
 
   const cut = tvs.dpe_class_limit[ca][Math.round(Sh)] ?? [];
@@ -318,7 +318,7 @@ function classe_bilan_dpe(ep_conso_5_usages_m2, zc_id, ca_id, Sh) {
   return 'G';
 }
 
-function classe_emission_ges(emission_ges_5_usages_m2, zc_id, ca_id, Sh) {
+export function classe_emission_ges(emission_ges_5_usages_m2, zc_id, ca_id, Sh) {
   const ca = enums.classe_altitude[ca_id];
 
   const cut = tvs.ges_class_limit[ca][Math.round(Sh)] ?? [];

--- a/src/engine.js
+++ b/src/engine.js
@@ -7,7 +7,7 @@ import calc_besoin_ch from './9_besoin_ch.js';
 import calc_chauffage, { tauxChargeForGenerator } from './9_chauffage.js';
 import calc_confort_ete from './2021_04_13_confort_ete.js';
 import calc_qualite_isolation from './2021_04_13_qualite_isolation.js';
-import calc_conso from './conso.js';
+import calc_conso, { classe_bilan_dpe, classe_emission_ges } from './conso.js';
 import {
   add_references,
   bug_for_bug_compat,
@@ -491,4 +491,30 @@ export function calcul_3cl(dpe) {
   };
 
   return dpe;
+}
+
+/**
+ * Retourne les classes calculées ges dpe.
+ * @param dpe {FullDpe}
+ * @returns {{dpeClass: string, gesClass: string}}
+ */
+export function get_classe_ges_dpe(dpe) {
+  const zc_id = dpe.logement.meteo.enum_zone_climatique_id;
+  const ca_id = dpe.logement.meteo.enum_classe_altitude_id;
+  const th = calc_th(dpe.logement.caracteristique_generale.enum_methode_application_dpe_log_id);
+
+  let Sh;
+  if (th === 'maison' || th === 'appartement')
+    Sh = dpe.logement.caracteristique_generale.surface_habitable_logement;
+  else if (th === 'immeuble') Sh = dpe.logement.caracteristique_generale.surface_habitable_immeuble;
+
+  return {
+    dpeClass: classe_bilan_dpe(dpe.logement.sortie.ep_conso.ep_conso_5_usages_m2, zc_id, ca_id, Sh),
+    gesClass: classe_emission_ges(
+      dpe.logement.sortie.emission_ges.emission_ges_5_usages_m2,
+      zc_id,
+      ca_id,
+      Sh
+    )
+  };
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { calcul_3cl } from './engine.js';
-export { calcul_3cl };
+import { calcul_3cl, get_classe_ges_dpe } from './engine.js';
+export { calcul_3cl, get_classe_ges_dpe };
 import { Umur, Uph, Upb, Uporte, Ubv, Upt } from './3_deperdition.js';
 export { Umur, Uph, Upb, Uporte, Ubv, Upt };

--- a/types.d.ts
+++ b/types.d.ts
@@ -77,6 +77,7 @@ interface Caracteristique_generale {
   enum_periode_construction_id: string;
   enum_methode_application_dpe_log_id: string;
   surface_habitable_logement: number;
+  surface_habitable_immeuble?: number;
   nombre_niveau_logement: number;
   hsp: number;
   nombre_appartement: number;


### PR DESCRIPTION
Ajout d'une fonction `get_classe_ges_dpe` pour calculer les classes DPE / GES. 
Utile notamment dans le cas des surfaces < 40 m² pour le calcul des nouvelles classes sans avoir  à executer le moteur