### PR TITLE
feat: #83 - ajout methode calcul cep 1.9 (janvier 2026)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import { calcul_3cl, get_classe_ges_dpe } from './src/index.js';
-export { calcul_3cl, get_classe_ges_dpe };
+import { calcul_3cl, get_classe_ges_dpe, get_conso_coeff_1_9_2026 } from './src/index.js';
+export { calcul_3cl, get_classe_ges_dpe, get_conso_coeff_1_9_2026 };
 import { Umur, Uph, Upb, Uporte, Ubv, Upt, calc_deperdition } from './src/3_deperdition.js';
 export { Umur, Uph, Upb, Uporte, Ubv, Upt, calc_deperdition };

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { calcul_3cl, get_classe_ges_dpe } from './engine.js';
-export { calcul_3cl, get_classe_ges_dpe };
+import { calcul_3cl, get_classe_ges_dpe, get_conso_coeff_1_9_2026 } from './engine.js';
+export { calcul_3cl, get_classe_ges_dpe, get_conso_coeff_1_9_2026 };
 import { Umur, Uph, Upb, Uporte, Ubv, Upt } from './3_deperdition.js';
 export { Umur, Uph, Upb, Uporte, Ubv, Upt };

--- a/types.d.ts
+++ b/types.d.ts
@@ -406,8 +406,11 @@ interface Ep_conso {
   ep_conso_fr: number;
   ep_conso_fr_depensier: number;
   ep_conso_5_usages: number;
+  ep_conso_5_usages_2026?: number;
   ep_conso_5_usages_m2: number;
+  ep_conso_5_usages_2026_m2?: number;
   classe_bilan_dpe: string;
+  classe_bilan_dpe_2026?: string;
 }
 interface Emission_ges {
   emission_ges_ch: number;


### PR DESCRIPTION
ajout d'une méthode qui permet de calculer la future consommation / classes dpe suite à  la mise à jour du CEP en 1.9 (et non plus 2.3) qui sera appliqué en janvier 2026

 [ https://www.ecologie.gouv.fr/actualites/evolutions-du-calcul-du-dpe-reponses-vos-questions#:~:text=Les%20DPE%20r%C3%A9alis%C3%A9s%20avant%20le,%2DAudit%20de%20l'Ademe.](https://www.ecologie.gouv.fr/actualites/evolutions-du-calcul-du-dpe-reponses-vos-questions#:~:text=Les%20DPE%20r%C3%A9alis%C3%A9s%20avant%20le,%2DAudit%20de%20l'Ademe.)

Closes #83 