### PR TITLE
fix(mur): doublage ne doit pas être cumulé si isolation ITE ou ITI présente

### DIFF
--- a/src/3.2.1_mur.js
+++ b/src/3.2.1_mur.js
@@ -167,7 +167,14 @@ function calc_umur0(di, de, du) {
   }
 
   // Si présence d'un doublage
-  if (type_doublage > 2) {
+  // En accord avec la méthode 3CL et LICIEL, le doublage ne doit PAS être cumulé
+  // si une isolation ITE ou ITI est présente (types 3=iti, 4=ite, 6=iti+ite).
+  // Pour une isolation ITR (5, 7, 8), inconnu (1) ou non isolé (2), le doublage est pris en compte.
+  // @see https://github.com/Open3CL/engine/issues/146
+  const typeIsolation = parseInt(de.enum_type_isolation_id);
+  const hasIteOrIti = [3, 4, 6].includes(typeIsolation);
+
+  if (type_doublage > 2 && !hasIteOrIti) {
     let umur0Doublage;
 
     // 3 - doublage indéterminé ou lame d'air inf 15 mm

--- a/src/3.2.1_mur.spec.js
+++ b/src/3.2.1_mur.spec.js
@@ -45,3 +45,122 @@ describe('Recherche de bugs dans le calcul de déperdition des murs', () => {
     expect(mur.donnee_intermediaire.umur0).toBe(2.5);
   });
 });
+
+/**
+ * @see https://github.com/Open3CL/engine/issues/146
+ * Lorsqu'un doublage est présent ET une isolation ITE ou ITI également,
+ * le doublage NE doit PAS être cumulé dans le calcul de Umur0.
+ * Il l'est en revanche pour une isolation ITR (intrinsèque au matériau).
+ */
+describe('[Issue #146] Doublage NE doit PAS être cumulé à une isolation ITE ou ITI', () => {
+  /**
+   * Cas de base : mur en blocs de béton creux 25cm (id 12), sans isolation.
+   * umur0 brut = 2.3 => après min(2.5) = 2.3
+   * Avec doublage type 4 (>15mm) sans isolation : umur0 = 1/(1/2.3 + 0.21) ≈ 1.5509
+   */
+  test('Doublage appliqué si isolation non présente (non isolé, type 2)', () => {
+    const mur = {
+      donnee_entree: {
+        description: 'Mur blocs béton creux 25cm non isolé avec doublage >15mm',
+        enum_materiaux_structure_mur_id: '12',
+        enum_methode_saisie_u0_id: '2',
+        epaisseur_structure: 25,
+        enum_type_doublage_id: '4', // doublage >15mm
+        enum_type_isolation_id: '2', // non isolé
+        enum_methode_saisie_u_id: '1', // non isolé
+        enum_type_adjacence_id: '1',
+        surface_paroi_totale: 10
+      },
+      donnee_intermediaire: {}
+    };
+    calc_mur(mur, 3, 1, 0);
+    // doublage doit être appliqué : umur0 ≈ 1.5509
+    expect(mur.donnee_intermediaire.umur0).toBeCloseTo(1.5509103169251517, 4);
+  });
+
+  test('Doublage NON appliqué si isolation ITI présente (type 3)', () => {
+    const mur = {
+      donnee_entree: {
+        description: 'Mur blocs béton creux 25cm avec ITI et doublage >15mm',
+        enum_materiaux_structure_mur_id: '12',
+        enum_methode_saisie_u0_id: '2',
+        epaisseur_structure: 25,
+        enum_type_doublage_id: '4', // doublage >15mm
+        enum_type_isolation_id: '3', // ITI
+        epaisseur_isolation: 4, // 4cm
+        enum_methode_saisie_u_id: '3', // épaisseur isolation saisie
+        enum_type_adjacence_id: '1',
+        surface_paroi_totale: 10
+      },
+      donnee_intermediaire: {}
+    };
+    calc_mur(mur, 3, 1, 0);
+    // doublage ignoré : umur0 = min(2.5, 2.3) = 2.3
+    expect(mur.donnee_intermediaire.umur0).toBeCloseTo(2.3, 4);
+    // umur = 1 / (1/2.3 + 0.04/0.04) = 1 / (1/2.3 + 1) ≈ 0.6970
+    expect(mur.donnee_intermediaire.umur).toBeCloseTo(1 / (1 / 2.3 + 1), 4);
+  });
+
+  test('Doublage NON appliqué si isolation ITE présente (type 4)', () => {
+    const mur = {
+      donnee_entree: {
+        description: 'Mur blocs béton creux 25cm avec ITE et doublage >15mm',
+        enum_materiaux_structure_mur_id: '12',
+        enum_methode_saisie_u0_id: '2',
+        epaisseur_structure: 25,
+        enum_type_doublage_id: '4', // doublage >15mm
+        enum_type_isolation_id: '4', // ITE
+        epaisseur_isolation: 4, // 4cm
+        enum_methode_saisie_u_id: '3', // épaisseur isolation saisie
+        enum_type_adjacence_id: '1',
+        surface_paroi_totale: 10
+      },
+      donnee_intermediaire: {}
+    };
+    calc_mur(mur, 3, 1, 0);
+    // doublage ignoré : umur0 = min(2.5, 2.3) = 2.3
+    expect(mur.donnee_intermediaire.umur0).toBeCloseTo(2.3, 4);
+  });
+
+  test('Doublage NON appliqué si isolation ITI+ITE présente (type 6)', () => {
+    const mur = {
+      donnee_entree: {
+        description: 'Mur blocs béton creux 25cm avec ITI+ITE et doublage >15mm',
+        enum_materiaux_structure_mur_id: '12',
+        enum_methode_saisie_u0_id: '2',
+        epaisseur_structure: 25,
+        enum_type_doublage_id: '5', // doublage connu (plâtre brique bois)
+        enum_type_isolation_id: '6', // ITI+ITE
+        epaisseur_isolation: 4,
+        enum_methode_saisie_u_id: '3',
+        enum_type_adjacence_id: '1',
+        surface_paroi_totale: 10
+      },
+      donnee_intermediaire: {}
+    };
+    calc_mur(mur, 3, 1, 0);
+    // doublage ignoré : umur0 = min(2.5, 2.3) = 2.3
+    expect(mur.donnee_intermediaire.umur0).toBeCloseTo(2.3, 4);
+  });
+
+  test('Doublage APPLIQUÉ si isolation ITR présente (type 5) — isolation intrinsèque', () => {
+    const mur = {
+      donnee_entree: {
+        description: 'Mur blocs béton creux 25cm avec ITR et doublage >15mm',
+        enum_materiaux_structure_mur_id: '12',
+        enum_methode_saisie_u0_id: '2',
+        epaisseur_structure: 25,
+        enum_type_doublage_id: '4', // doublage >15mm
+        enum_type_isolation_id: '5', // ITR
+        epaisseur_isolation: 4,
+        enum_methode_saisie_u_id: '3',
+        enum_type_adjacence_id: '1',
+        surface_paroi_totale: 10
+      },
+      donnee_intermediaire: {}
+    };
+    calc_mur(mur, 3, 1, 0);
+    // doublage appliqué : umur0 ≈ 1.5509
+    expect(mur.donnee_intermediaire.umur0).toBeCloseTo(1.5509103169251517, 4);
+  });
+});

--- a/src/features/engine/domain/enveloppe/mur/deperdition-mur.service.js
+++ b/src/features/engine/domain/enveloppe/mur/deperdition-mur.service.js
@@ -129,20 +129,30 @@ export class DeperditionMurService extends DeperditionService {
     }
 
     /**
-     * Pour l’ensemble des parois, la présence d’un doublage apporte une résistance thermique supplémentaire
+     * Pour l’ensemble des parois, la présence d’un doublage apporte une résistance thermique supplémentaire.
+     * Cependant, en accord avec la méthode 3CL et le comportement de LICIEL, lorsqu'une isolation ITE ou ITI
+     * est présente (types 3, 4, 6), le doublage ne doit PAS être cumulé.
+     * Le doublage est en revanche pris en compte pour une isolation ITR (type 5, 7, 8) car c'est une isolation
+     * intrinsèque au matériau, ainsi que pour les cas inconnus (1) ou non isolé (2).
+     * @see https://github.com/Open3CL/engine/issues/146
      */
-    switch (murDE.enum_type_doublage_id) {
-      case '3':
-        // doublage indéterminé ou lame d'air inf 15 mm
-        umur0 = 1 / (1 / umur0 + 0.1);
-        break;
-      case '4': // doublage indéterminé ou lame d'air sup 15 mm
-      case '5': // doublage connu (plâtre brique bois)
-        umur0 = 1 / (1 / umur0 + 0.21);
-        break;
-      default:
-        // absence de doublage ou inconnu
-        break;
+    const typeIsolation = parseInt(murDE.enum_type_isolation_id);
+    const hasIteOrIti = [3, 4, 6].includes(typeIsolation);
+
+    if (!hasIteOrIti) {
+      switch (murDE.enum_type_doublage_id) {
+        case '3':
+          // doublage indéterminé ou lame d'air inf 15 mm
+          umur0 = 1 / (1 / umur0 + 0.1);
+          break;
+        case '4': // doublage indéterminé ou lame d'air sup 15 mm
+        case '5': // doublage connu (plâtre brique bois)
+          umur0 = 1 / (1 / umur0 + 0.21);
+          break;
+        default:
+          // absence de doublage ou inconnu
+          break;
+      }
     }
 
     /**

--- a/src/features/engine/domain/enveloppe/mur/deperdition-mur.service.spec.js
+++ b/src/features/engine/domain/enveloppe/mur/deperdition-mur.service.spec.js
@@ -53,6 +53,70 @@ describe('Calcul de déperdition des murs', () => {
         zoneClimatiqueId: '3',
         umurExpected: 0.8, // 0.7 dans le DPE original, mais certainement lié à une erreur
         umur0Expected: 1.55091
+      },
+      // Issue #146 : doublage NON cumulé si isolation ITI présente (type 3)
+      {
+        label:
+          '[Issue #146] Mur blocs béton creux 25cm avec doublage >15mm et isolation ITI — doublage ignoré',
+        enumMateriauxStructureMurId: '12',
+        enumMethodeSaisieUId: '3',
+        enumMethodeSaisieU0Id: '2',
+        paroiAncienne: false,
+        enumTypeIsolationId: '3', // ITI
+        enumTypeDoublageId: '4', // doublage >15mm
+        epaisseurStructure: 25,
+        epaisseurIsolation: 4,
+        zoneClimatiqueId: '3',
+        umur0Expected: 2.3, // doublage ignoré : umur0 brut = 2.3, min(2.5, 2.3) = 2.3
+        umurExpected: 1 / (1 / 2.3 + 1) // 1/(1/2.3 + 0.04/0.04)
+      },
+      // Issue #146 : doublage NON cumulé si isolation ITE présente (type 4)
+      {
+        label:
+          '[Issue #146] Mur blocs béton creux 25cm avec doublage >15mm et isolation ITE — doublage ignoré',
+        enumMateriauxStructureMurId: '12',
+        enumMethodeSaisieUId: '3',
+        enumMethodeSaisieU0Id: '2',
+        paroiAncienne: false,
+        enumTypeIsolationId: '4', // ITE
+        enumTypeDoublageId: '4', // doublage >15mm
+        epaisseurStructure: 25,
+        epaisseurIsolation: 4,
+        zoneClimatiqueId: '3',
+        umur0Expected: 2.3, // doublage ignoré
+        umurExpected: 1 / (1 / 2.3 + 1)
+      },
+      // Issue #146 : doublage NON cumulé si isolation ITI+ITE présente (type 6)
+      {
+        label:
+          '[Issue #146] Mur blocs béton creux 25cm avec doublage connu et isolation ITI+ITE — doublage ignoré',
+        enumMateriauxStructureMurId: '12',
+        enumMethodeSaisieUId: '3',
+        enumMethodeSaisieU0Id: '2',
+        paroiAncienne: false,
+        enumTypeIsolationId: '6', // ITI+ITE
+        enumTypeDoublageId: '5', // doublage connu
+        epaisseurStructure: 25,
+        epaisseurIsolation: 4,
+        zoneClimatiqueId: '3',
+        umur0Expected: 2.3, // doublage ignoré
+        umurExpected: 1 / (1 / 2.3 + 1)
+      },
+      // Issue #146 : doublage APPLIQUÉ si isolation ITR présente (type 5) — intrinsèque au matériau
+      {
+        label:
+          '[Issue #146] Mur blocs béton creux 25cm avec doublage >15mm et isolation ITR — doublage appliqué',
+        enumMateriauxStructureMurId: '12',
+        enumMethodeSaisieUId: '3',
+        enumMethodeSaisieU0Id: '2',
+        paroiAncienne: false,
+        enumTypeIsolationId: '5', // ITR
+        enumTypeDoublageId: '4', // doublage >15mm
+        epaisseurStructure: 25,
+        epaisseurIsolation: 4,
+        zoneClimatiqueId: '3',
+        umur0Expected: 1.55091, // doublage appliqué
+        umurExpected: 1 / (1 / 1.5509103169251517 + 1)
       }
     ])(
       '$label',
@@ -64,6 +128,7 @@ describe('Calcul de déperdition des murs', () => {
         enumTypeIsolationId,
         umurSaisi,
         epaisseurStructure,
+        epaisseurIsolation,
         paroiAncienne,
         resistanceIsolation,
         umurExpected,
@@ -91,6 +156,7 @@ describe('Calcul de déperdition des murs', () => {
           resistance_isolation: resistanceIsolation,
           paroi_ancienne: paroiAncienne,
           epaisseur_structure: epaisseurStructure,
+          epaisseur_isolation: epaisseurIsolation,
           enum_type_doublage_id: enumTypeDoublageId,
           enum_type_isolation_id: enumTypeIsolationId,
           enum_periode_isolation_id: enumIsolationId


### PR DESCRIPTION
## Description

Fixes #146

En accord avec la méthode 3CL et le comportement de LICIEL, lorsquun doublage est présent **ET** quune isolation **ITE** (type 4), **ITI** (type 3) ou **ITI+ITE** (type 6) est également présente, le doublage ne doit **pas** être pris en compte dans le calcul de `Umur0`.

Le doublage reste appliqué pour une isolation **ITR** (types 5, 7, 8) car cest une isolation intrinsèque au matériau, ainsi que pour les cas non isolé (type 2) ou isolation inconnue (type 1).

## Comportement avant correction

Pour un mur avec doublage >15mm **et** une ITI dépaisseur 4cm :
```
Umurdoublage = 1 / ((1/Umur0) + R_doublage)
Umur = 1 / ((1/Umurdoublage) + e/0.04)
```

## Comportement après correction

```
Umur = 1 / ((1/Umurnu) + e/0.04)   ← Umurnu sans doublage
```

## Fichiers modifiés

- `src/3.2.1_mur.js` — correction dans `calc_umur0`
- `src/features/engine/domain/enveloppe/mur/deperdition-mur.service.js` — correction dans `#umur0`
- `src/3.2.1_mur.spec.js` — 5 nouveaux tests
- `src/features/engine/domain/enveloppe/mur/deperdition-mur.service.spec.js` — 4 nouveaux cas