### PR TITLE
fix(ets): Sse_ver ne doit pas être calculé sans baie intérieure vers l'ETS (#140)

### DIFF
--- a/src/6.2_surface_sud_equivalente.js
+++ b/src/6.2_surface_sud_equivalente.js
@@ -6,15 +6,27 @@ export function calc_sse_j(bv_list, ets, ca, zc, mois) {
   const baiesAdjVeranda = bv_list.filter((bv) => bv.donnee_entree.enum_type_adjacence_id === '10');
   const baiesAdjExt = bv_list.filter((bv) => bv.donnee_entree.enum_type_adjacence_id === '1');
 
+  const sseBaiesExt = baiesAdjExt.reduce((acc, bv) => {
+    return acc + getSsd(bv, zc, mois, bv.donnee_intermediaire.sw);
+  }, 0);
+
   if (!ets) {
-    return baiesAdjExt.reduce((acc, bv) => {
-      return acc + getSsd(bv, zc, mois, bv.donnee_intermediaire.sw);
-    }, 0);
+    return sseBaiesExt;
   }
 
   // Certaines vérandas sont dupliqués dans les DPE.
   if (Array.isArray(ets)) {
     ets = ets[0];
+  }
+
+  /**
+   * S'il n'existe aucune baie vitrée séparant l'ETS du reste du logement
+   * (type_adjacence = 10), les apports solaires de l'ETS ne peuvent pas
+   * pénétrer dans la partie habitable : Sse_ver ne doit pas être calculé.
+   * Cf. méthode 3CL §6.3 et issue #140.
+   */
+  if (baiesAdjVeranda.length === 0) {
+    return sseBaiesExt;
   }
 
   const bver = ets.donnee_intermediaire.bver;
@@ -30,8 +42,8 @@ export function calc_sse_j(bv_list, ets, ca, zc, mois) {
   }
 
   /**
-   * Surface sud équivalente représentant l’impact des apports solaires associés au rayonnement solaire
-   * traversant directement l’espace tampon pour arriver dans la partie habitable du logement
+   * Surface sud équivalente représentant l'impact des apports solaires associés au rayonnement solaire
+   * traversant directement l'espace tampon pour arriver dans la partie habitable du logement
    * Calculés pour les baies vitrées qui séparent le logement de l'espace tampon
    * @type {number}
    */
@@ -39,9 +51,9 @@ export function calc_sse_j(bv_list, ets, ca, zc, mois) {
     T *
     baiesAdjVeranda.reduce((acc, bv) => {
       /**
-       * Surface sud équivalente représentant l’impact des apports solaires associés au rayonnement solaire
-       * traversant directement l’espace tampon pour arriver dans la partie habitable du logement
-       * Calculés pour les baies vitrées qui séparent le logement de l'espace tampon
+       * Surface sud équivalente représentant l'impact des apports solaires associés au rayonnement solaire
+       * traversant directement l'espace tampon pour arriver dans la partie habitable du logement
+       * Calculés pour les baies vitrées qui séparant le logement de l'espace tampon
        * @type {number}
        */
       return acc + getSsd(bv, zc, mois, bv.donnee_intermediaire.sw);
@@ -56,22 +68,18 @@ export function calc_sse_j(bv_list, ets, ca, zc, mois) {
   }, 0);
 
   /**
-   * Surface sud équivalente représentant l’impact des apports solaires associés au rayonnement
-   * solaire entrant dans la partie habitable du logement après de multiples réflexions dans l’espace tampon solarisé
+   * Surface sud équivalente représentant l'impact des apports solaires associés au rayonnement
+   * solaire entrant dans la partie habitable du logement après de multiples réflexions dans l'espace tampon solarisé
    * @type {number}
    */
   const ssIndj = Sstj - Ssdj;
 
   /**
-   * Impact de l’espace tampon solarisé sur les apports solaires à travers les baies vitrées qui séparent le logement
+   * Impact de l'espace tampon solarisé sur les apports solaires à travers les baies vitrées qui séparent le logement
    * de l'espace tampon
    * @type {number}
    */
   const SseVerandaj = Ssdj + ssIndj * bver;
-
-  const sseBaiesExt = baiesAdjExt.reduce((acc, bv) => {
-    return acc + getSsd(bv, zc, mois, bv.donnee_intermediaire.sw);
-  }, 0);
 
   return sseBaiesExt + SseVerandaj;
 }

--- a/src/features/engine/domain/apport_et_besoin/surface-sud-equivalente-ets-no-interior-bay.spec.js
+++ b/src/features/engine/domain/apport_et_besoin/surface-sud-equivalente-ets-no-interior-bay.spec.js
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { SurfaceSudEquivalenteService } from './surface-sud-equivalente.service.js';
+import { BaieVitreeTvStore } from '../../../dpe/infrastructure/enveloppe/baieVitreeTv.store.js';
+
+/**
+ * Tests de non-régression pour le fix du ticket #140 :
+ * "La surface sud équivalente véranda ne doit PAS être calculée
+ *  s'il n'y a pas de baies séparant l'ETS du reste du logement"
+ *
+ * Méthode 3CL §6.3 : Sse_ver = 0 si aucune baie vitrée du logement
+ * n'a type_adjacence = 10 (espace tampon solarisé).
+ */
+
+/** @type {SurfaceSudEquivalenteService} **/
+let service;
+
+/** @type {BaieVitreeTvStore} **/
+let tvStore;
+
+describe("[Issue #140] ETS - Sse_ver sans baie intérieure vers l'ETS", () => {
+  beforeEach(() => {
+    tvStore = new BaieVitreeTvStore();
+    service = new SurfaceSudEquivalenteService(tvStore);
+  });
+
+  test("ETS avec uniquement des baies vers l'extérieur (pas de type_adjacence=10) : Sse_ver = 0", () => {
+    vi.spyOn(tvStore, 'getCoefficientBaieVitree').mockReturnValue(0.5);
+
+    /** @type {Contexte} */
+    const ctx = { zoneClimatique: { id: 1 } };
+
+    /**
+     * DPE comportant un ETS avec uniquement des baies vers l'extérieur (baie_ets)
+     * mais aucune baie vitrée du logement donnant sur l'ETS (type_adjacence = 10).
+     * Cas de reproduction : DPE 2518E0102737H
+     *
+     * @type {Enveloppe}
+     */
+    const enveloppe = {
+      baie_vitree_collection: {
+        baie_vitree: [
+          {
+            // Baie extérieure du logement (type_adjacence = 1)
+            donnee_entree: {
+              enum_type_adjacence_id: 1,
+              enum_orientation_id: 2,
+              surface_totale_baie: 10
+            },
+            donnee_intermediaire: { sw: 1 }
+          }
+        ]
+      },
+      ets_collection: {
+        ets: {
+          donnee_intermediaire: { bver: 0.6, coef_transparence_ets: 0.4 },
+          baie_ets_collection: {
+            baie_ets: {
+              donnee_entree: {
+                enum_inclinaison_vitrage_id: 3,
+                enum_orientation_id: 1,
+                surface_totale_baie: 7
+              }
+            }
+          }
+        }
+      }
+    };
+
+    // surface(10) * C1(0.5) * sw(1) * fe1(1) * fe2(1) = 5 pour la baie extérieure
+    // Sse_ver = 0 car aucune baie type_adjacence=10
+    const result = service.ssdMois(ctx, enveloppe, 'Janvier');
+
+    expect(result).toBe(5);
+    // Le getCoefficientBaieVitree ne doit être appelé qu'une seule fois
+    // (pour la baie extérieure, pas pour les baies ETS)
+    expect(tvStore.getCoefficientBaieVitree).toHaveBeenCalledTimes(1);
+    expect(tvStore.getCoefficientBaieVitree).toHaveBeenCalledWith(2, 3, 1, 'Janvier');
+  });
+
+  test('ETS avec baie intérieure (type_adjacence=10) ET baie extérieure : Sse_ver est calculé normalement', () => {
+    vi.spyOn(tvStore, 'getCoefficientBaieVitree').mockReturnValue(0.5);
+
+    /** @type {Contexte} */
+    const ctx = { zoneClimatique: { id: 1 } };
+
+    /** @type {Enveloppe} */
+    const enveloppe = {
+      baie_vitree_collection: {
+        baie_vitree: [
+          {
+            // Baie intérieure logement→ETS (type_adjacence = 10)
+            donnee_entree: {
+              enum_type_adjacence_id: 10,
+              enum_orientation_id: 2,
+              surface_totale_baie: 10
+            },
+            donnee_intermediaire: { sw: 1 }
+          },
+          {
+            // Baie extérieure du logement (type_adjacence = 1)
+            donnee_entree: {
+              enum_type_adjacence_id: 1,
+              enum_orientation_id: 2,
+              surface_totale_baie: 10
+            },
+            donnee_intermediaire: { sw: 1 }
+          }
+        ]
+      },
+      ets_collection: {
+        ets: {
+          donnee_intermediaire: { bver: 0.6, coef_transparence_ets: 0.4 },
+          baie_ets_collection: {
+            baie_ets: {
+              donnee_entree: {
+                enum_inclinaison_vitrage_id: 3,
+                enum_orientation_id: 1,
+                surface_totale_baie: 7
+              }
+            }
+          }
+        }
+      }
+    };
+
+    // T = 0.4, bver = 0.6
+    // C1 = 0.5 (mocké pour toutes les baies)
+    //
+    // Ssdj = T * ssdBaieMois(bv_adjacence_10) = 0.4 * (10 * 0.5 * 1 * 1 * 1) = 2
+    // Sstj = ssdBaieMois(baie_ets, coeff=0.8*T+0.024) = 7 * 0.5 * (0.8*0.4+0.024) * 1 * 1
+    //      = 7 * 0.5 * 0.344 = 1.204
+    // Ssindj = Sstj - Ssdj = 1.204 - 2 = -0.796
+    // SseVerandaj = Ssdj + Ssindj * bver = 2 + (-0.796) * 0.6 = 2 - 0.4776 = 1.5224
+    //
+    // Contribution baie type_adjacence=10 : SseVerandaj = 1.5224
+    // Contribution baie type_adjacence=1  : ssdBaieMois = 10 * 0.5 * 1 = 5
+    // Total = 1.5224 + 5 = 6.5224
+    expect(service.ssdMois(ctx, enveloppe, 'Janvier')).toBe(6.5224);
+  });
+
+  test("ETS sans collection de baies vers l'ETS (ets_collection absent) : seulement les baies extérieures", () => {
+    vi.spyOn(tvStore, 'getCoefficientBaieVitree').mockReturnValue(0.5);
+
+    /** @type {Contexte} */
+    const ctx = { zoneClimatique: { id: 1 } };
+
+    /** @type {Enveloppe} */
+    const enveloppe = {
+      baie_vitree_collection: {
+        baie_vitree: [
+          {
+            donnee_entree: {
+              enum_type_adjacence_id: 1,
+              enum_orientation_id: 2,
+              surface_totale_baie: 10
+            },
+            donnee_intermediaire: { sw: 1 }
+          }
+        ]
+      }
+      // Pas de ets_collection
+    };
+
+    expect(service.ssdMois(ctx, enveloppe, 'Janvier')).toBe(5);
+  });
+});

--- a/src/features/engine/domain/apport_et_besoin/surface-sud-equivalente.service.js
+++ b/src/features/engine/domain/apport_et_besoin/surface-sud-equivalente.service.js
@@ -47,7 +47,7 @@ export class SurfaceSudEquivalenteService {
     let SseVerandaj = 0;
 
     /**
-     * Si une véranda est présente, on calcul l'mpact de l’espace tampon solarisé sur les apports solaires à travers
+     * Si une véranda est présente, on calcul l'impact de l'espace tampon solarisé sur les apports solaires à travers
      * les baies vitrées qui séparent le logement de l'espace tampon
      *
      * 6.3 Traitement des espaces tampons solarisés
@@ -59,17 +59,25 @@ export class SurfaceSudEquivalenteService {
         ets = ets[0];
       }
 
-      if (ets) {
+      /**
+       * S'il n'existe aucune baie vitrée séparant l'ETS du reste du logement
+       * (type_adjacence = 10), les apports solaires de l'ETS ne peuvent pas
+       * pénétrer dans la partie habitable : Sse_ver ne doit pas être calculé.
+       * Cf. méthode 3CL §6.3 et issue #140.
+       */
+      const baiesVersEts = this.getBaiesSurEspaceTampon(baiesVitrees);
+
+      if (ets && baiesVersEts.length > 0) {
         const bver = ets.donnee_intermediaire.bver;
         const T = ets.donnee_intermediaire.coef_transparence_ets;
 
         /**
-         * Surface sud équivalente représentant l’impact des apports solaires associés au rayonnement solaire
-         * traversant directement l’espace tampon pour arriver dans la partie habitable du logement
+         * Surface sud équivalente représentant l'impact des apports solaires associés au rayonnement solaire
+         * traversant directement l'espace tampon pour arriver dans la partie habitable du logement
          * Calculés pour les baies vitrées qui séparent le logement de l'espace tampon
          * @type {number}
          */
-        const Ssdj = this.getBaiesSurEspaceTampon(baiesVitrees).reduce((acc, bv) => {
+        const Ssdj = baiesVersEts.reduce((acc, bv) => {
           return acc + T * this.ssdBaieMois(bv, ctx.zoneClimatique.id, mois);
         }, 0);
 
@@ -91,14 +99,14 @@ export class SurfaceSudEquivalenteService {
         }, 0);
 
         /**
-         * Surface sud équivalente représentant l’impact des apports solaires indirects associés au rayonnement
-         * solaire entrant dans la partie habitable du logement après de multiples réflexions dans l’espace tampon solarisé
+         * Surface sud équivalente représentant l'impact des apports solaires indirects associés au rayonnement
+         * solaire entrant dans la partie habitable du logement après de multiples réflexions dans l'espace tampon solarisé
          * @type {number}
          */
         const Ssindj = Sstj - Ssdj;
 
         /**
-         * Impact de l’espace tampon solarisé sur les apports solaires à travers les baies vitrées qui séparent le logement
+         * Impact de l'espace tampon solarisé sur les apports solaires à travers les baies vitrées qui séparent le logement
          * de l'espace tampon
          * @type {number}
          */


### PR DESCRIPTION
## Problème

Un ETS (Espace Tampon Solarisé / véranda) comporte deux types de baies :
1. Les **baies ETS→extérieur** (`baie_ets`)
2. Les **baies logement→ETS** (`type_adjacence = 10`)

Selon la méthode 3CL §6.3, la surface sud équivalente véranda (`Sse_ver`) ne doit être calculée que si des baies vitrées séparant le logement de l'ETS existent (`type_adjacence = 10`). Sans elles, les apports solaires de l'ETS ne peuvent physiquement pas pénétrer dans la partie habitable.

Or Open3CL calculait `Sse_ver` même en l'absence de telles baies, ce qui produit des apports solaires artificiels.

**DPE de reproduction :** `2518E0102737H` (ETS sans baie intérieure)

## Solution

Ajout d'un guard `baiesAdjVeranda.length === 0` (ancien code `6.2_surface_sud_equivalente.js`) et `baiesVersEts.length > 0` (nouveau service refactorisé) pour court-circuiter le calcul de `Sse_ver` lorsqu'aucune baie n'est adjacente à l'ETS côté logement.

## Fichiers modifiés

- `src/6.2_surface_sud_equivalente.js` — code legacy
- `src/features/engine/domain/apport_et_besoin/surface-sud-equivalente.service.js` — service refactorisé
- `src/features/engine/domain/apport_et_besoin/surface-sud-equivalente-ets-no-interior-bay.spec.js` — nouveaux tests unitaires (3 scénarios)

Closes #140